### PR TITLE
Update Constants.h

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -10,7 +10,7 @@
 
 
 #define WIDTH 1280
-#define HEIGHT WIDTH / 16 * 9 // aspect ratio
+#define HEIGHT (WIDTH / 16 * 9) // aspect ratio
 
 
 


### PR DESCRIPTION
Hello,
Consider the case: ` double whatever = 1.0 / HEIGHT` . This is converted to ` 1.0 / WIDTH / 16 * 9`  in the way you've written this.
"define" does exactly this, it copy pastes at compile time. Do you see the problem here? In C/C++ operations with same priority (such as multiplication and division) are applied from left to right.
Therefore it multiplies the number by 9, where it should multiply the denominator by 9 (i.e. divide by 9)
It produces a different and unexpected number when you use height in even such a simple equation. You can approve my pull request or change it yourself, but putting it to paranthesis fixes the problem.
